### PR TITLE
[FIX] yahoo.py crash_list_index_out_of_range

### DIFF
--- a/searx/engines/yahoo.py
+++ b/searx/engines/yahoo.py
@@ -33,7 +33,7 @@ supported_languages_url = 'https://search.yahoo.com/web/advanced'
 results_xpath = "//div[contains(concat(' ', normalize-space(@class), ' '), ' Sr ')]"
 url_xpath = './/h3/a/@href'
 title_xpath = './/h3/a'
-content_xpath = './/div[@class="compText aAbs"]'
+content_xpath = ('.//div[@class="compText aAbs"/text()]')[0]
 suggestion_xpath = "//div[contains(concat(' ', normalize-space(@class), ' '), ' AlsoTry ')]//a"
 
 time_range_dict = {'day': ['1d', 'd'],
@@ -123,7 +123,7 @@ def response(resp):
         except:
             continue
 
-        content = extract_text(eval_xpath(result, content_xpath)[0])
+        content = extract_text(eval_xpath(result, content_xpath))
 
         # append result
         results.append({'url': url,


### PR DESCRIPTION
#### @ in search {pageno=4} =>    yahoo (unexpected crash list index out of range)
```
"searx/engines/yahoo.py", line 126, in response
    content = extract_text(eval_xpath(result, content_xpath)[0])
IndexError: list index out of range
```
#### I SUGGEST:
@ line https://github.com/asciimoo/searx/blob/master/searx/engines/yahoo.py#L36
content_xpath = ('.//div[@class="compText aAbs"/text()]')[0]
@ line https://github.com/asciimoo/searx/blob/master/searx/engines/yahoo.py#L126
content = extract_text(eval_xpath(result, content_xpath))

#### AFTER:
pass search {pageno=4} whitout errors